### PR TITLE
Btchip experimental nfc

### DIFF
--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -25,6 +25,12 @@
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
             </intent-filter>
             <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" android:resource="@xml/device_filter" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="android.nfc.action.TECH_DISCOVERED" />
+            </intent-filter>
+            <meta-data android:name="android.nfc.action.TECH_DISCOVERED" android:resource="@xml/nfc_tech_filter" />
         </activity>
         <activity-alias android:name="it.greenaddress.cordova.ui.MainActivityUrlAlias" android:targetActivity="GreenAddressIt">
             <intent-filter>

--- a/platforms/android/res/xml/nfc_tech_filter.xml
+++ b/platforms/android/res/xml/nfc_tech_filter.xml
@@ -1,0 +1,7 @@
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <tech-list>
+        <tech>android.nfc.tech.NfcA</tech>
+	<tech>android.nfc.tech.IsoDep</tech>
+    </tech-list>
+</resources>
+

--- a/platforms/android/src/com/btchip/comm/android/BTChipTransportAndroidNFC.java
+++ b/platforms/android/src/com/btchip/comm/android/BTChipTransportAndroidNFC.java
@@ -1,3 +1,22 @@
+/*
+*******************************************************************************    
+*   BTChip Bitcoin Hardware Wallet Java API
+*   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
+*   
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*   limitations under the License.
+********************************************************************************
+*/
+
 package com.btchip.comm.android;
 
 import android.nfc.tech.IsoDep;

--- a/platforms/android/src/com/btchip/comm/android/BTChipTransportAndroidNFC.java
+++ b/platforms/android/src/com/btchip/comm/android/BTChipTransportAndroidNFC.java
@@ -1,0 +1,75 @@
+package com.btchip.comm.android;
+
+import android.nfc.tech.IsoDep;
+import android.util.Log;
+
+import com.btchip.BTChipException;
+import com.btchip.comm.BTChipTransport;
+import com.btchip.utils.Dump;
+
+public class BTChipTransportAndroidNFC implements BTChipTransport {
+	
+	public static final int DEFAULT_TIMEOUT = 5000;
+	
+	private IsoDep card;
+	private int timeout;
+	private boolean debug;	
+	
+	public BTChipTransportAndroidNFC(IsoDep card, int timeout) {
+		this.card = card;
+		this.timeout = timeout;
+	}
+	
+	public BTChipTransportAndroidNFC(IsoDep card) {
+		this(card, DEFAULT_TIMEOUT);
+	}
+	
+
+	@Override
+	public byte[] exchange(byte[] command) throws BTChipException {
+		try {
+			if (!card.isConnected()) {
+				card.connect();
+				card.setTimeout(timeout);
+				if (debug) {
+					Log.d(BTChipTransportAndroid.LOG_STRING, "Connected");
+				}
+			}
+			if (debug) {
+				Log.d(BTChipTransportAndroid.LOG_STRING, "=> " + Dump.dump(command));
+			}
+			byte[] commandLe = new byte[command.length + 1];
+			System.arraycopy(command, 0, commandLe, 0, command.length);
+			byte[] response = card.transceive(commandLe);
+			if (debug) {
+				Log.d(BTChipTransportAndroid.LOG_STRING, "<= " + Dump.dump(response));
+			}
+			return response;			
+		}
+		catch(Exception e) {
+			try {
+				card.close();
+			}
+			catch(Exception e1) {				
+			}
+			throw new BTChipException("I/O error", e);
+		}
+		
+	}
+
+	@Override
+	public void close() throws BTChipException {
+		try {
+			if (card.isConnected()) {
+				card.close();
+			}			
+		}
+		catch(Exception e) {			
+		}
+	}
+
+	@Override
+	public void setDebug(boolean debugFlag) {
+		this.debug = debugFlag;
+	}
+}

--- a/platforms/android/src/it/greenaddress/cordova/GreenAddressIt.java
+++ b/platforms/android/src/it/greenaddress/cordova/GreenAddressIt.java
@@ -21,6 +21,7 @@ package it.greenaddress.cordova;
 
 import com.btchip.comm.BTChipTransport;
 import com.btchip.comm.android.BTChipTransportAndroid;
+import com.btchip.comm.android.BTChipTransportAndroidNFC;
 import com.btchip.utils.Dump;
 
 import android.os.Bundle;
@@ -33,6 +34,8 @@ import android.preference.PreferenceManager;
 import android.nfc.NdefMessage;
 import android.nfc.NdefRecord;
 import android.nfc.NfcAdapter;
+import android.nfc.tech.IsoDep;
+import android.nfc.Tag;
 import java.util.logging.Logger;
 import android.os.Parcelable;
 import android.net.Uri;
@@ -73,7 +76,13 @@ public class GreenAddressIt extends CordovaActivity
             System.out.println("Dongle detected");
             UsbManager manager = (UsbManager) getSystemService(Context.USB_SERVICE);
             BTChip.transport = BTChipTransportAndroid.open(manager, device);
+	    BTChip.transport.setDebug(true);
         }
+	Tag tag = (Tag) getIntent().getParcelableExtra(NfcAdapter.EXTRA_TAG);
+	if ((tag != null) && (NfcAdapter.ACTION_TECH_DISCOVERED.equals(getIntent().getAction()))) {
+	    BTChip.transport = new BTChipTransportAndroidNFC(IsoDep.get(tag));
+	    BTChip.transport.setDebug(true);
+	}
 
         if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(getIntent().getAction()) && getIntent().getBooleanExtra("continue", true)) {
             // ignore nfc, to avoid having nfc service and app not reparenting (disappears from history) and send intent just to start app normally

--- a/plugins/it.greenaddress.cordova/GreenAddressIt.java
+++ b/plugins/it.greenaddress.cordova/GreenAddressIt.java
@@ -21,6 +21,7 @@ package it.greenaddress.cordova;
 
 import com.btchip.comm.BTChipTransport;
 import com.btchip.comm.android.BTChipTransportAndroid;
+import com.btchip.comm.android.BTChipTransportAndroidNFC;
 import com.btchip.utils.Dump;
 
 import android.os.Bundle;
@@ -33,6 +34,8 @@ import android.preference.PreferenceManager;
 import android.nfc.NdefMessage;
 import android.nfc.NdefRecord;
 import android.nfc.NfcAdapter;
+import android.nfc.tech.IsoDep;
+import android.nfc.Tag;
 import java.util.logging.Logger;
 import android.os.Parcelable;
 import android.net.Uri;
@@ -73,7 +76,13 @@ public class GreenAddressIt extends CordovaActivity
             System.out.println("Dongle detected");
             UsbManager manager = (UsbManager) getSystemService(Context.USB_SERVICE);
             BTChip.transport = BTChipTransportAndroid.open(manager, device);
+	    BTChip.transport.setDebug(true);
         }
+	Tag tag = (Tag) getIntent().getParcelableExtra(NfcAdapter.EXTRA_TAG);
+	if ((tag != null) && (NfcAdapter.ACTION_TECH_DISCOVERED.equals(getIntent().getAction()))) {
+	    BTChip.transport = new BTChipTransportAndroidNFC(IsoDep.get(tag));
+	    BTChip.transport.setDebug(true);
+	}
 
         if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(getIntent().getAction()) && getIntent().getBooleanExtra("continue", true)) {
             // ignore nfc, to avoid having nfc service and app not reparenting (disappears from history) and send intent just to start app normally


### PR DESCRIPTION
Experimental NFC transport, to be tested with GreenBits or on an experimental branch (having fun in Miami, all that).

Only work to log-in, would need disabling NFC/reenabling when sending, without triggering a new action restarting the app.